### PR TITLE
Fix `type_sum()` scoping

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -128,10 +128,8 @@ as.list.quantities <- function(x, ...)
 #'   export(pillar_shaft.quantities)
 #' }
 type_sum.quantities <- function(x) {
-  if (getRversion() >= "3.6.0") {
-    type_sum.errors <- utils::getS3method("type_sum", "errors")
-    type_sum.units <- utils::getS3method("type_sum", "units")
-  }
+  type_sum.errors <- utils::getS3method("type_sum", "errors", envir = asNamespace("pillar"))
+  type_sum.units <- utils::getS3method("type_sum", "units", envir = asNamespace("pillar"))
   out <- gsub("\\[|\\]", "", paste(type_sum.errors(x), type_sum.units(x)))
   paste0("[", out, "]")
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,25 +1,6 @@
 library(testthat)
 library(quantities)
 
-expect_quantities <- function(x, xval, xunt, xerr) {
-  expect_equal(class(x), c("quantities", "units", "errors"))
-  expect_equal(as.numeric(x), xval)
-  expect_equal(as.character(attr(x, "units")), as.character(xunt))
-  expect_equal(attr(x, "errors"), xerr)
-}
-
-expect_errors <- function(x, xval, xerr) {
-  expect_equal(class(x), "errors")
-  expect_equal(as.numeric(x), xval)
-  expect_equal(attr(x, "errors"), xerr)
-}
-
-expect_units <- function(x, xval, xunt) {
-  expect_equal(class(x), "units")
-  expect_equal(as.numeric(x), xval)
-  expect_equal(as.character(attr(x, "units")), as.character(xunt))
-}
-
 test_check("quantities")
 
 detach("package:quantities", unload = TRUE)

--- a/tests/testthat/helper-quantities.R
+++ b/tests/testthat/helper-quantities.R
@@ -1,0 +1,19 @@
+
+expect_quantities <- function(x, xval, xunt, xerr) {
+  expect_equal(class(x), c("quantities", "units", "errors"))
+  expect_equal(as.numeric(x), xval)
+  expect_equal(as.character(attr(x, "units")), as.character(xunt))
+  expect_equal(attr(x, "errors"), xerr)
+}
+
+expect_errors <- function(x, xval, xerr) {
+  expect_equal(class(x), "errors")
+  expect_equal(as.numeric(x), xval)
+  expect_equal(attr(x, "errors"), xerr)
+}
+
+expect_units <- function(x, xval, xunt) {
+  expect_equal(class(x), "units")
+  expect_equal(as.numeric(x), xval)
+  expect_equal(as.character(attr(x, "units")), as.character(xunt))
+}

--- a/tests/testthat/output/tibble-print.txt
+++ b/tests/testthat/output/tibble-print.txt
@@ -1,0 +1,12 @@
+> x <- set_quantities(1:3, "cm", 3:1, mode = "standard")
+> x
+Units: [cm]
+Errors: 3 2 1
+[1] 1 2 3
+
+> tibble::tibble(x = x)
+Error in utils::getS3method("type_sum", "errors"): no function 'type_sum' could be found
+
+> tibble::tibble(tibble::tibble(x = x))
+Error in utils::getS3method("type_sum", "errors"): no function 'type_sum' could be found
+

--- a/tests/testthat/output/tibble-print.txt
+++ b/tests/testthat/output/tibble-print.txt
@@ -5,8 +5,18 @@ Errors: 3 2 1
 [1] 1 2 3
 
 > tibble::tibble(x = x)
-Error in utils::getS3method("type_sum", "errors"): no function 'type_sum' could be found
+# A tibble: 3 x 1
+             x
+  <[(err) cm]>
+1      1(3) cm
+2      2(2) cm
+3      3(1) cm
 
 > tibble::tibble(tibble::tibble(x = x))
-Error in utils::getS3method("type_sum", "errors"): no function 'type_sum' could be found
+# A tibble: 3 x 1
+             x
+  <[(err) cm]>
+1      1(3) cm
+2      2(2) cm
+3      3(1) cm
 

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -1,0 +1,12 @@
+
+test_that("can print quantities in tibble", {
+  skip_if_not_installed("tibble")
+
+  verify_output(test_path("output", "tibble-print.txt"), {
+    x <- set_quantities(1:3, "cm", 3:1, mode = "standard")
+
+    x
+    tibble::tibble(x = x)
+    tibble::tibble(tibble::tibble(x = x))
+  })
+})


### PR DESCRIPTION
* Move testthat helpers to helper file so it works with `devtools::test()`.

* Specify pillar namespace so `getS3method()` can find the generic (since it's not imported).

* Remove the conditionality on R 3.6 since we're moving towards backward compatible lazy registration in {errors} and {units}. This fixes a bug on old R versions where `type_sum.errors` and `type_sum.units` would not be defined even though they are used after the `if`.

* Tibble output is tested with `verify_output()`. This creates a monitoring test that never causes CRAN check failures when the output changes. When the output changes because of internal and upstream changes, testthat will update the output file and the change can be committed at your convenience. See https://www.tidyverse.org/blog/2019/11/testthat-2-3-0/ for a high level presentation of `verify_output()`.

Before:

```r
x <- set_quantities(1:3, "cm", 3:1, mode = "standard")

tibble::tibble(x)
#> Error: no function 'type_sum' could be found
```

After:

```r
tibble::tibble(x)
#> # A tibble: 3 x 1
#>              x
#>   <[(err) cm]>
#> 1      1(3) cm
#> 2      2(2) cm
#> 3      3(1) cm
```